### PR TITLE
データ詳細の修正

### DIFF
--- a/src/components/play/layout/CenterPanel.tsx
+++ b/src/components/play/layout/CenterPanel.tsx
@@ -30,7 +30,7 @@ interface CenterPanelProps {
   onInplayCommit: () => void;
   onStrikeoutCommit: (isSwinging: boolean) => void;
   onWalkCommit: () => void;
-  onRunnerMovement: (battingResult: string, position: string) => void;
+  onRunnerMovement: (battingResult: string, details: { position: string; batType: string }) => void;
   onRunnersChange: (next: { '1': string | null; '2': string | null; '3': string | null }) => void;
   onCountsChange: (next: { b?: number; s?: number; o?: number }) => void;
   onCountsReset: () => void;

--- a/src/components/play/pitch/PitchResultSelector.tsx
+++ b/src/components/play/pitch/PitchResultSelector.tsx
@@ -92,11 +92,11 @@ const PitchResultSelector: React.FC<PitchResultSelectorProps> = ({
   onCancel,
 }) => {
   const results: Array<{ key: 'swing' | 'looking' | 'ball' | 'inplay' | 'deadball' | 'foul'; label: string }> = [
-    { key: 'swing', label: 'スイング' },
     { key: 'looking', label: '見逃し' },
+    { key: 'swing', label: 'スイング' }, 
+    { key: 'foul', label: 'ファウル' },
     { key: 'ball', label: 'ボール' },
     { key: 'deadball', label: 'デッドボール' },
-    { key: 'foul', label: 'ファウル' },
     { key: 'inplay', label: 'インプレイ' },
   ];
 

--- a/src/components/play/playresult/PlayResultForm.tsx
+++ b/src/components/play/playresult/PlayResultForm.tsx
@@ -11,8 +11,14 @@ interface PlayResultFormProps {
   outfieldDirection: string;
   setOutfieldDirection: (v: string) => void;
   outfieldDirectionOptions: Array<{ value: string; label: string }>;
+  // 追加: batType
+  batType: string;
+  setBatType: (v: string) => void;
+  batTypeOptions: Array<{ value: string; label: string }>;
+  
   needsPosition: boolean;
   needsOutfieldDirection: boolean;
+  needsBatType: boolean;
   isFormValid: boolean;
   onSubmit: () => void;
   onCancel?: () => void;
@@ -29,8 +35,14 @@ const PlayResultForm: React.FC<PlayResultFormProps> = ({
   outfieldDirection,
   setOutfieldDirection,
   outfieldDirectionOptions,
+  // 追加
+  batType,
+  setBatType,
+  batTypeOptions,
+  
   needsPosition,
   needsOutfieldDirection,
+  needsBatType,
   isFormValid,
   onSubmit,
   onCancel,
@@ -101,6 +113,48 @@ const PlayResultForm: React.FC<PlayResultFormProps> = ({
         ))}
       </div>
     </div>
+    
+    {/* 打球タイプ選択（追加） */}
+    {needsBatType && (
+      <div style={{ marginBottom: 20 }}>
+        <label style={{
+          display: 'block',
+          marginBottom: 8,
+          fontWeight: 600,
+          fontSize: 14,
+          color: '#495057',
+        }}>
+          打球タイプ <span style={{ color: '#e74c3c' }}>*</span>
+        </label>
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 1fr)',
+          gap: 8,
+        }}>
+          {batTypeOptions.map(option => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => setBatType(option.value)}
+              style={{
+                padding: '10px 12px',
+                background: batType === option.value ? '#fd7e14' : '#f8f9fa',
+                color: batType === option.value ? '#fff' : '#495057',
+                border: batType === option.value ? '2px solid #fd7e14' : '1px solid #dee2e6',
+                borderRadius: 6,
+                cursor: 'pointer',
+                fontWeight: batType === option.value ? 600 : 400,
+                fontSize: 13,
+                transition: 'all 0.2s ease',
+              }}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    )}
+
     {/* 打球方向選択（必要な場合のみ表示） */}
     {needsPosition && (
       <div style={{ marginBottom: 20 }}>

--- a/src/types/AtBat.ts
+++ b/src/types/AtBat.ts
@@ -49,6 +49,8 @@ export interface PitchRecord {
   seq: number;
   type: PitchType;
   course: number; // 1-25 (StrikeZoneGridのグリッド番号)
+  x?: number; // 0-100% (左上が0,0)
+  y?: number; // 0-100%
   result: PitchResult;
   velocity?: number | null;
 }
@@ -73,12 +75,14 @@ export interface RunnerEvent {
 }
 
 export type BatType = 'ground' | 'fly' | 'liner' | 'bunt';
-export type BatDirection = 'left' | 'center' | 'right' | 'infield';
+
+// 打球方向は既存の定義を維持しつつ、将来的にポジション番号も入れられるようにしておく
+export type BatDirection = 'left' | 'center' | 'right' | 'infield' | string;
 
 export interface FieldingAction {
-  playerId: string;
+  playerId?: string; // IDが不明な場合も許容
   position: string;
-  action: 'fielded' | 'assist' | 'error';
+  action: 'fielded' | 'assist' | 'putout' | 'error'; // putout(刺殺)を追加
   quality: 'clean' | 'bobbled' | 'missed';
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Capture batType/position in play results and precise pitch coordinates; update at-bat saving, fielding details, and pitcher strike/ball logic.
> 
> - **Play flow and UI**:
>   - Pass detailed play info (`{ position, batType }`) instead of just position across `PlayResultPanel` → parent handlers.
>   - Add bat type selection to `PlayResultForm`; validate alongside position/direction.
>   - When no runners and an out, skip runner input, immediately persist at-bat, advance order, and reset counts; standardize `playId` to `${matchId}_###`.
> - **Pitch recording**:
>   - Compute `course` from coordinates and store normalized `x`/`y` (%) in `PitchRecord` instead of hardcoded values.
>   - Count `inplay` as strike and `deadball` as ball in pitcher stats; tweak pitch result selector order.
> - **At-bat persistence**:
>   - Save richer `playDetails` (includes `batType`, `direction`, and derived `fielding` actions for fly/ground outs and runner-out details).
>   - Include full pitch records on strikeouts, in-play, walks/deadballs; reset runners on half-inning close.
> - **Types** (`src/types/AtBat.ts`):
>   - Extend `PitchRecord` with optional `x`/`y`.
>   - Allow `FieldingAction.action` to include `putout` and make `playerId` optional; broaden `BatDirection` to accept position strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69136692caeb873aae0efe14d4055829e5bfe04b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->